### PR TITLE
Optional SSL redirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ This container provides three main components:
 
 The image configures itself via environment variables:
 
-| Environment Variable   | Description                                                                                               |
-|------------------------|-----------------------------------------------------------------------------------------------------------|
-| `VARNISH_BACKEND_ELB`  | The hostname of the S3 ELB (e.g. `example.com.s3-website-us-east-1.amazonaws.com`).                       |
-| `VARNISH_BACKEND_HOST` | The hostname to be sent to the backend as the `Host` header (e.g. `example.com`).                         |
-| `VARNISH_BACKEND_PORT` | The port the backend will listening on (optional, defaults to 80).                                        |
-| `DATADOG_API_KEY`      | Your [datadog](http://datadoghq.com) API key (datadog agent won't be started if this isn't provided).     |
-| `DATADOG_TAGS`         | An optional, comma-delimited list of tags for datadog.                                                    |
+| Environment Variable             | Description                                                                                           |
+|----------------------------------|-------------------------------------------------------------------------------------------------------|
+| `VARNISH_BACKEND_ELB`            | The hostname of the S3 ELB (e.g. `example.com.s3-website-us-east-1.amazonaws.com`).                   |
+| `VARNISH_BACKEND_HOST`           | The hostname to be sent to the backend as the `Host` header (e.g. `example.com`).                     |
+| `VARNISH_BACKEND_PORT`           | The port the backend will listening on (optional, defaults to 80).                                    |
+| `VARNISH_BACKEND_FORCE_SSL`      | When set to "true", rewrite requests to SSL                                                           |
+| `VARNISH_BACKEND_FORCE_SSL_HOST` | For use with VARNISH_BACKEND_FORCE_SSL. https host to redirect to.                                    |
+| `DATADOG_API_KEY`                | Your [datadog](http://datadoghq.com) API key (datadog agent won't be started if this isn't provided). |
+| `DATADOG_TAGS`                   | An optional, comma-delimited list of tags for datadog.                                                |
 
 These env variables can be set in the Beanstalk environment configuration.
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -14,6 +14,9 @@ http {
 	server {
 		listen 127.0.0.1:8080;
 		location / {
+			if ($http_x_forwarded_proto = "http" && "${VARNISH_BACKEND_FORCE_SSL}" = "true") {
+				rewrite  ^/(.*)$  https://${VARNISH_BACKEND_FORCE_SSL_HOST}/$1 permanent;
+			}
 			proxy_pass http://${VARNISH_BACKEND_ELB};
 			proxy_set_header Host ${VARNISH_BACKEND_HOST};
 		}

--- a/start.sh
+++ b/start.sh
@@ -3,6 +3,8 @@
 VARNISH_BACKEND_PORT=${VARNISH_BACKEND_PORT-80}
 VARNISH_BACKEND_ELB=${VARNISH_BACKEND_ELB-example.com}
 VARNISH_BACKEND_HOST=${VARNISH_BACKEND_HOST-example.com}
+VARNISH_BACKEND_FORCE_SSL=${VARNISH_BACKEND_FORCE_SSL-false}
+VARNISH_BACKEND_FORCE_SSL_HOST=${VARNISH_BACKEND_FORCE_SSL-example.com}
 
 function replace_env() {
   local file="${1?}"
@@ -14,7 +16,12 @@ function replace_env() {
   done
 }
 
-replace_env /etc/nginx/nginx.conf VARNISH_BACKEND_PORT VARNISH_BACKEND_ELB VARNISH_BACKEND_HOST
+replace_env /etc/nginx/nginx.conf \
+            VARNISH_BACKEND_PORT \
+            VARNISH_BACKEND_ELB \
+            VARNISH_BACKEND_HOST \
+            VARNISH_BACKEND_FORCE_SSL \
+            VARNISH_BACKEND_FORCE_SSL_HOST
 
 if [ -n "$DATADOG_API_KEY" ]; then
   replace_env /etc/dd-agent/datadog.conf DATADOG_API_KEY DATADOG_TAGS


### PR DESCRIPTION
- Added two variables to configure optional SSL redirection
- One variable turns redirection on, the other configures which host to
redirect TO
- Use the x-forwarded-proto header because ELB serves the SSL and we
want to avoid infinite loop.